### PR TITLE
relax jsonschema, fix test invocation

### DIFF
--- a/recipe/0000-relax-json-schema-pin.patch
+++ b/recipe/0000-relax-json-schema-pin.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 3c81d63..deb9d90 100644
+--- a/setup.py
++++ b/setup.py
+@@ -2,7 +2,7 @@ from setuptools import setup
+ 
+ requires = [
+     "python-dateutil>=2.8,<2.9",
+-    "jsonschema<4.0,>=3.0",
++    "jsonschema>=3.0",
+     'dataclasses>=0.6,<0.9;python_version<"3.7"',
+ ]
+ 

--- a/recipe/0001-use-default-factory.patch
+++ b/recipe/0001-use-default-factory.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/conftest.py b/tests/conftest.py
+index 955bbb1..71c1eae 100644
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -68,7 +68,7 @@ class Bar(JsonSchemaMixin):
+ class Baz(JsonSchemaMixin):
+     """Type with nested default value"""
+ 
+-    a: Point = field(default=Point(0.0, 0.0))
++    a: Point = field(default_factory=lambda: Point(0.0, 0.0))
+ 
+ 
+ @dataclass

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,26 @@
-{% set name = "hologram" %}
 {% set version = "0.0.15" %}
 
 
 package:
-  name: {{ name|lower }}
+  name: hologram
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/hologram-{{ version }}.tar.gz
-  sha256: 79b3d04df84d5a9d09c2e669ec5bcc50b1713ec79f4683cfdea85583b41e46f0
+  - folder: dist
+    url: https://pypi.io/packages/source/h/hologram/hologram-{{ version }}.tar.gz
+    sha256: 79b3d04df84d5a9d09c2e669ec5bcc50b1713ec79f4683cfdea85583b41e46f0
+    patches:
+      - 0000-relax-json-schema-pin.patch
+  - folder: src
+    url: https://github.com/dbt-labs/hologram/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: 5c9c04c6dd22d2cebb9d1ff156f462ef350e8d6ba08294ce8940fc3b2841b9c9
+    patches:
+      - 0001-use-default-factory.patch
 
 build:
   noarch: python
-  number: 1
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 2
+  script: cd dist && {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   host:
@@ -26,14 +33,22 @@ requirements:
     - python-dateutil >=2.8,<2.9
 
 test:
+  source_files:
+    - src/tests
+  requires:
+    - pip
+    - pytest-cov
   imports:
     - hologram
+  commands:
+    - pip check
+    - pytest -vv src/tests --cov=hologram --cov-branch --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=90
 
 about:
   home: https://github.com/fishtown-analytics/hologram
   summary: JSON schema generation from dataclasses
   license: MIT
-  license_file: LICENSE
+  license_file: dist/LICENSE
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Notes:
- restores `pip check` from #2
  - patches the `jsonschema` dependency in `setup.py`
    - upstream PR: https://github.com/dbt-labs/hologram/pull/51
- adds tests
  - patches to use `default_factory`
    - upstream PR: https://github.com/dbt-labs/hologram/pull/50
  - adds coverage, with a 90% threshold
    - while it's _possible_ there's something in the remaining 10% of coverage that will break with `jsonschema>3`, i'd be _much_ more confident shipping this

References:
- blocks https://github.com/conda-forge/dagster-feedstock/pull/239